### PR TITLE
Refresh PATH after WinGet installation

### DIFF
--- a/Scripts/ps_Deploy-Device.ps1
+++ b/Scripts/ps_Deploy-Device.ps1
@@ -323,9 +323,9 @@ function Invoke-Deployment {
         @{ 
             Script = 'ps_Install-Drivers.ps1'
             Name = 'Driver Updates'
-            RequiresNetwork = $false
-            RequiresStableNetwork = $false
-            Critical = $false
+            RequiresNetwork = $true
+            RequiresStableNetwork = $true
+            Critical = $true
         },
         @{ 
             Script = 'ps_Install-Applications.ps1'

--- a/Scripts/ps_Install-Applications.ps1
+++ b/Scripts/ps_Install-Applications.ps1
@@ -46,15 +46,16 @@
     Installs 7zip, PowerShell 7, and Microsoft Teams.
 
 .RELEASENOTES
-    1.0.0 Initial release
-    1.1.0 Added PowerShell 7 installation and improved logging
-    2.0.0 Added WinGet support and enhanced error handling
-    2.1.0 Improved the handling of Teams installation
-    2.1.1 Bugfix: Fixed installation not executing (Start-Process issue) + improved logging with output capture
-    2.1.2 Improved logging and exit code handling for WinGet installations
+ [Version 1.0.0] - Initial release
+ [Version 1.1.0] - Added PowerShell 7 installation and improved logging
+ [Version 2.0.0] - Added WinGet support and enhanced error handling
+ [Version 2.1.0] - Improved the handling of Teams installation
+ [Version 2.1.1] - Bugfix: Fixed installation not executing (Start-Process issue) + improved logging with output capture
+ [Version 2.1.2] - Improved logging and exit code handling for WinGet installations
+ [Version 2.1.3] - Added refresh of environment PATH after winget installation to ensure winget is available in the current session.
 
 .NOTES
-    Version:  2.1.2
+    Version:  2.1.3
     Author:   Sten Tijhuis
     Company:  Denko ICT
     Requires: Admin rights, WinGet
@@ -190,6 +191,10 @@ try {
             Write-Log "PowerShell 7 MSI not found at: $PowerShell7Path" -Level Warning
         }
     }
+    
+    # Refresh environment PATH to ensure WinGet is available
+    Write-Log "Refreshing environment PATH..." -Level Info
+    $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH", "User")
     
     # Check WinGet availability
     Write-Log "Checking WinGet availability..." -Level Info

--- a/Scripts/ps_Install-Winget.ps1
+++ b/Scripts/ps_Install-Winget.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 5.2.2
+.VERSION 5.2.3
 
 .AUTHOR Sten Tijhuis
 
@@ -85,6 +85,7 @@
     "endLineNumber": 745,
 }]
 [Version 5.2.2] - Fixed 2 typos on line 1119 ".SYNOPSIS". and line 179 "Location".
+[Version 5.2.3] - Added Refresh environment PATH after winget installation to ensure winget is available in the current session.
 
 #>
 
@@ -118,7 +119,7 @@ This script is designed to be straightforward and easy to use, removing the hass
 .PARAMETER Help
     Displays the full help information for the script.
 .NOTES
-    Version      : 5.2.2
+    Version      : 5.2.3
     Created by   : Sten Tijhuis
     Original Author: https://github.com/asheroto/winget-install
 .LINK
@@ -1488,6 +1489,14 @@ try {
     Write-Section "Complete"
 
     Write-Output "winget installed successfully."
+
+    # ============================================================================ #
+    # Refresh environment PATH
+    # ============================================================================ #
+    
+    Write-Output "Refreshing environment PATH..."
+    $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH", "User")
+    Write-Debug "Updated PATH for current session"
 
     # ============================================================================ #
     # Finished


### PR DESCRIPTION
Updated scripts to refresh the environment PATH after installing WinGet, ensuring it is available in the current session.